### PR TITLE
Update build_tsc.js

### DIFF
--- a/app/templates/tasks/server/build_tsc.js
+++ b/app/templates/tasks/server/build_tsc.js
@@ -7,7 +7,7 @@ gulp.task("server.compile_tsc", () => {
   let tsconfigSrc = tsc.createProject(TS_CONFIG);
 
   return tsconfigSrc.src()
-                    .pipe(tsc(tsconfigSrc))
+                    .pipe(tsconfigSrc())
                     .js
                     .pipe(gulp.dest("."));
 });


### PR DESCRIPTION
Replace deprecated function by recommendation: ts(tsProject) -> .pipe(tsProject(reporter))